### PR TITLE
repair a bug  related to judge POLLIN event

### DIFF
--- a/socket/echoser_poll.c
+++ b/socket/echoser_poll.c
@@ -114,7 +114,7 @@ int main(void)
 			conn = client[i].fd;
 			if (conn == -1)
 				continue;
-			if (client[i].events & POLLIN) {
+			if (client[i].revents & POLLIN) {
 				
 				char recvbuf[1024] = {0};
 				int ret = readline(conn, recvbuf, 1024);


### PR DESCRIPTION
change "client[i].events & POLLIN" to "client[i].revents & POLLIN"